### PR TITLE
Links to data instead of copying

### DIFF
--- a/hooks/init
+++ b/hooks/init
@@ -3,3 +3,11 @@
 cp -r {{pkg.path}}/neo4j/ {{pkg.svc_var_path}}
 chown -R hab:hab {{pkg.svc_var_path}}
 
+#Link config
+rm -rf {{pkg.svc_var_path}}/neo4j/conf
+ln -s {{pkg.svc_config_path}} {{pkg.svc_var_path}}/neo4j/conf
+
+#Link data
+rm -rf {{pkg.svc_var_path}}/neo4j/data
+ln -s {{pkg.svc_data_path}} {{pkg.svc_var_path}}/neo4j/data
+

--- a/hooks/run
+++ b/hooks/run
@@ -4,9 +4,6 @@ exec 2>&1
 
 export JAVA_HOME=$(hab pkg path core/jre8)
 
-#Copy over config
-cp {{pkg.svc_config_path}}/* {{pkg.svc_var_path}}/neo4j/conf
-
 cd {{pkg.svc_var_path}}/neo4j
 
 exec bin/neo4j console


### PR DESCRIPTION
Links both data and config directories so the Habitat conventions are
more accurately followed.

Fixes #4
